### PR TITLE
Don't favor Chrome, and offer alternatives.

### DIFF
--- a/0/interacting-with-your-node.md
+++ b/0/interacting-with-your-node.md
@@ -3,9 +3,11 @@ Interacting With Your Node
 
 By the end of this tutorial we will have you create your own custom UI to interact with your collectables blockchain. In the meantime, we can use the [Polkadot-JS](https://polkadot.js.org) Apps UI which is a generalized interface that adapts to your custom node.
 
-Open **Chrome** and navigate to:
+In your web browser, navigate to:
 
 https://polkadot.js.org/apps/
+
+> Some browsers, notably firefox, will not connect to a local node from an https website. An easy work around is to try another browser, like Chromium. Another option is the [host this interface locally](https://github.com/polkadot-js/apps#development).
 
 To point the UI to your local node, you need to adjust the **Settings**. Just select 'Local Node (127.0.0.1:9944)' from the endpoint dropdown:
 

--- a/0/interacting-with-your-node.md
+++ b/0/interacting-with-your-node.md
@@ -7,7 +7,7 @@ In your web browser, navigate to:
 
 https://polkadot.js.org/apps/
 
-> Some browsers, notably firefox, will not connect to a local node from an https website. An easy work around is to try another browser, like Chromium. Another option is the [host this interface locally](https://github.com/polkadot-js/apps#development).
+> Some browsers, notably Firefox, will not connect to a local node from an https website. An easy work around is to try another browser, like Chromium. Another option is the [host this interface locally](https://github.com/polkadot-js/apps#development).
 
 To point the UI to your local node, you need to adjust the **Settings**. Just select 'Local Node (127.0.0.1:9944)' from the endpoint dropdown:
 

--- a/0/interacting-with-your-node.md
+++ b/0/interacting-with-your-node.md
@@ -7,7 +7,7 @@ In your web browser, navigate to:
 
 https://polkadot.js.org/apps/
 
-> Some browsers, notably Firefox, will not connect to a local node from an https website. An easy work around is to try another browser, like Chromium. Another option is the [host this interface locally](https://github.com/polkadot-js/apps#development).
+> Some browsers, notably Firefox, will not connect to a local node from an https website. An easy work around is to try another browser, like Chromium. Another option is to [host this interface locally](https://github.com/polkadot-js/apps#development).
 
 To point the UI to your local node, you need to adjust the **Settings**. Just select 'Local Node (127.0.0.1:9944)' from the endpoint dropdown:
 


### PR DESCRIPTION
Some browser, notably Firefox, do not allow connecting to unsecured websockets (eg, a locally running Substrate node) via secured https websites (eg https://polkadot.js.org/apps/).

Previously the workshop had read
> Open Chrome and navigate to:

But users often interpret this as being unaware of other web browsers, or favoring Google products.

This PR changes to browser-neutral language, and offer suggestions for users who struggle with the http/ws issue described above.