### PR TITLE
Update URL for Polkadot JS Apps

### DIFF
--- a/0/interacting-with-your-node.md
+++ b/0/interacting-with-your-node.md
@@ -5,7 +5,7 @@ By the end of this tutorial we will have you create your own custom UI to intera
 
 Open **Chrome** and navigate to:
 
-https://polkadot.js.org/apps/
+https://substrate-ui.parity.io/
 
 To point the UI to your local node, you need to adjust the **Settings**. Just select 'Local Node (127.0.0.1:9944)' from the endpoint dropdown:
 

--- a/1/viewing-a-storage-mapping.md
+++ b/1/viewing-a-storage-mapping.md
@@ -16,7 +16,7 @@ We can start our node:
 ./target/release/substratekitties --dev
 ```
 
-If we go back into the [Polkadot-JS Apps UI](https://polkadot.js.org/apps), we should see evidence of our node producing blocks.
+If we go back into the [Polkadot-JS Apps UI](https://substrate-ui.parity.io/), we should see evidence of our node producing blocks.
 
 ## Submit a Transaction
 

--- a/ja-jp/1/viewing-a-storage-mapping.md
+++ b/ja-jp/1/viewing-a-storage-mapping.md
@@ -17,7 +17,7 @@ cargo build --release
 ./target/release/substratekitties --dev
 ```
 
-[Polkadot-JS Apps UI](https://polkadot.js.org/apps)に戻ると、ノードがブロックを生成しはじめるはずです。
+[Polkadot-JS Apps UI](https://substrate-ui.parity.io/)に戻ると、ノードがブロックを生成しはじめるはずです。
 
 ##トランザクションを送信する
 

--- a/zh-cn/0/interacting-with-your-node.md
+++ b/zh-cn/0/interacting-with-your-node.md
@@ -4,7 +4,7 @@
 
 打开 **Chrome** 并导航至:
 
-https://polkadot.js.org/apps/
+https://substrate-ui.parity.io/
 
 要将 UI 指向 local node，你需要调整 **设置**，只需从下拉列表中选择 'Local Node (127.0.0.1:9944)'：
 

--- a/zh-cn/1/viewing-a-storage-mapping.md
+++ b/zh-cn/1/viewing-a-storage-mapping.md
@@ -16,7 +16,7 @@ cargo build --release
 ./target/release/substratekitties --dev
 ```
 
-如果我们回到 [Polkadot-JS Apps UI](https://polkadot.js.org/apps)，我们应该看到我们的节点正在产生块。
+如果我们回到 [Polkadot-JS Apps UI](https://substrate-ui.parity.io/)，我们应该看到我们的节点正在产生块。
 
 ## 提交一个 Transaction
 


### PR DESCRIPTION
The main Polkadot JS Apps is no longer compatible with Substrate v1.0.

However https://substrate-ui.parity.io/ is.