### PR TITLE
fix Rust compiler intro wording

### DIFF
--- a/0/common-patterns-moving-forward.md
+++ b/0/common-patterns-moving-forward.md
@@ -3,7 +3,7 @@ Common Patterns Moving Forward
 
 ## The Rust Compiler is Your Friend
 
-One of the many advantages of using a strongly typed programming language like Rust is that the compiler can be very helpful and even suggest how to fix errors in your code. You can learn more about how the Rust compiler help you by reading [this post](https://jvns.ca/blog/2018/01/13/rust-in-2018--way-easier-to-use/). This will be obvious to you the most you write with Rust. To get started, you should check out the [Rust Book](https://doc.rust-lang.org/book/).
+One of the many advantages of using a strongly typed programming language like Rust is that the compiler can be very helpful and even suggest how to fix errors in your code. You can learn more about how the Rust compiler helps you by reading [this post](https://jvns.ca/blog/2018/01/13/rust-in-2018--way-easier-to-use/). This will become obvious to you the more you write with Rust. To get started, you should check out the [Rust Book](https://doc.rust-lang.org/book/).
 
 ## Making Updates to Your Runtime
 


### PR DESCRIPTION
Going through the Collectibles workshop at the moment and noticed a place to improve the wording.